### PR TITLE
fix syncableRef mapping

### DIFF
--- a/core/src/change/change-plant.ts
+++ b/core/src/change/change-plant.ts
@@ -7,6 +7,7 @@ import {
   AbstractSyncableObject,
   AbstractUserSyncableObject,
   ISyncable,
+  SyncableId,
   SyncableRef,
   SyncableType,
 } from '../syncable';
@@ -187,7 +188,7 @@ export class ChangePlant<
       {} as Dict<ISyncable>,
     );
 
-    let syncableObjectMap = new Map<string, AbstractSyncableObject>();
+    let syncableObjectMap = new Map<SyncableId, AbstractSyncableObject>();
 
     let syncableObjectDict = syncableObjectEntries.reduce(
       (dict, [name, object]) => {

--- a/core/src/change/change-plant.ts
+++ b/core/src/change/change-plant.ts
@@ -187,11 +187,11 @@ export class ChangePlant<
       {} as Dict<ISyncable>,
     );
 
-    let syncableObjectMap = new Map<ISyncable, AbstractSyncableObject>();
+    let syncableObjectMap = new Map<string, AbstractSyncableObject>();
 
     let syncableObjectDict = syncableObjectEntries.reduce(
       (dict, [name, object]) => {
-        syncableObjectMap.set(object.syncable, object);
+        syncableObjectMap.set(object.syncable._id, object);
 
         dict[name] = object;
 
@@ -227,7 +227,7 @@ export class ChangePlant<
       if (typeof removal === 'string') {
         object = syncableObjectDict[removal];
       } else {
-        object = syncableObjectMap.get(removal)!;
+        object = syncableObjectMap.get(removal._id)!;
       }
 
       object.validateAccessRights(['full'], context);

--- a/examples/design/src/client/main.ts
+++ b/examples/design/src/client/main.ts
@@ -3,13 +3,14 @@
 import 'source-map-support/register';
 
 import {Client} from '@syncable/client';
-import {ChangePlant} from '@syncable/core';
+import {ChangePlant, SyncableRef} from '@syncable/core';
 import {autorun} from 'mobx';
 
 import {
   MFChange,
   MFSyncableObject,
   MFSyncableObjectFactory,
+  Tag,
   User,
   mfChangePlantBlueprint,
 } from '../shared';
@@ -43,6 +44,11 @@ autorun(() => {
   }
 
   for (let tag of tags) {
-    client.update({type: 'tag:remove', refs: {tag}, options: {}});
+    // tag.ref: SyncableRef<Tag>
+    client.update({
+      type: 'tag:remove',
+      refs: {tag: tag.ref as SyncableRef<Tag>},
+      options: {},
+    });
   }
 })().catch(console.error);

--- a/examples/design/src/client/main.ts
+++ b/examples/design/src/client/main.ts
@@ -3,7 +3,7 @@
 import 'source-map-support/register';
 
 import {Client} from '@syncable/client';
-import {ChangePlant, SyncableRef} from '@syncable/core';
+import {ChangePlant} from '@syncable/core';
 import {autorun} from 'mobx';
 
 import {
@@ -37,17 +37,16 @@ autorun(() => {
   await client.ready;
 
   let user = client.user;
-  let tags = client.getObjects('tag');
+  let tags = client.getObjects<Tag>('tag');
 
   for (let tag of tags) {
     client.associate(user, tag, {requisite: true, name: 'tag'});
   }
 
   for (let tag of tags) {
-    // tag.ref: SyncableRef<Tag>
     client.update({
       type: 'tag:remove',
-      refs: {tag: tag.ref as SyncableRef<Tag>},
+      refs: {tag: tag.ref},
       options: {},
     });
   }


### PR DESCRIPTION
Problem

- example: design\src\client\main.ts
```ts
  for (let tag of tags) {
    // expected type inference for tag.ref: SyncableRef<Tag>
    client.update({
      type: 'tag:remove',
      refs: {tag: tag.ref as SyncableRef<Tag>},
      options: {},
    });
  }
```